### PR TITLE
fix: esbuild does not support top level await

### DIFF
--- a/packages/esbuild/esbuild.js
+++ b/packages/esbuild/esbuild.js
@@ -1,12 +1,11 @@
 import { build } from 'esbuild'
-import { polyfillNode } from 'esbuild-plugin-polyfill-node'
 import htmlPlugin from '@chialab/esbuild-plugin-html'
 
 await build({
   bundle: true,
   entryPoints: ['src/index.html'],
   outdir: 'dist',
-  plugins: [polyfillNode(), htmlPlugin()],
+  plugins: [htmlPlugin()],
   treeShaking: true,
   define: {
     'process.stdout.isTTY': 'false',

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@chialab/esbuild-plugin-html": "^0.17.3",
     "esbuild": "^0.19.3",
-    "esbuild-plugin-polyfill-node": "^0.3.0",
+    "events": "^3.3.0",
     "typescript": "latest"
   }
 }


### PR DESCRIPTION
Top level await happens in `polyfillNode` when polyfilling `worker_thread` in `flexsearch`.
It's optional in flexsearch, however it still polyfills it. Inside the `worker_thread` it's using top level await.
Sadly, `esbuild` doesnot support top level await for now even in es2022.
By removing `polyfillNode`, we know that it is actually designed to polyfill events which is a dependency of `file-type`.